### PR TITLE
Fix XML encoding to UTF-8

### DIFF
--- a/Controllers/CfdiController.cs
+++ b/Controllers/CfdiController.cs
@@ -172,8 +172,8 @@ namespace HG.CFDI.API.Controllers
 
                 if (response.Data != null && response.Data.archivoCFDi != null && response.Data.archivoCFDi.pdf.Length <= 0)
                 {
-                    // Convertir de byte[] a string
-                    string xmlCFDTimbrado = Encoding.ASCII.GetString(response.Data.archivoCFDi.xml);
+                    // Convertir de byte[] a string utilizando UTF-8 para evitar perdida de informacion
+                    string xmlCFDTimbrado = Encoding.UTF8.GetString(response.Data.archivoCFDi.xml);
 
                     byte[] pdfBytes = await _documentosService.getPdfTimbrado(xmlCFDTimbrado, database);
 
@@ -228,8 +228,8 @@ namespace HG.CFDI.API.Controllers
 
                 var response = await _cartaPorteService.getCartaPorte(database.ToLower(), num_guia);
 
-                // Convertir de byte[] a string
-                string xmlCFDTimbrado = Encoding.ASCII.GetString(response.Data.archivoCFDi.xml);
+                // Convertir de byte[] a string utilizando UTF-8 para evitar perdida de informacion
+                string xmlCFDTimbrado = Encoding.UTF8.GetString(response.Data.archivoCFDi.xml);
 
                 byte[] pdfBytes = await _documentosService.getPdfTimbrado(xmlCFDTimbrado, database);
 

--- a/HG.CFDI.SERVICE/Services/Timbrado/Documentos/DocumentosService.cs
+++ b/HG.CFDI.SERVICE/Services/Timbrado/Documentos/DocumentosService.cs
@@ -150,7 +150,8 @@ namespace HG.CFDI.SERVICE.Services.Timbrado.Documentos
         {
             //throw new System.Exception("💥 Error simulado en getPdfTimbrado ###");
 
-            byte[] xmlbytes = Encoding.ASCII.GetBytes(xmlCFDTimbrado);
+            // Utilizar UTF-8 para codificar el XML y evitar perdida de datos
+            byte[] xmlbytes = Encoding.UTF8.GetBytes(xmlCFDTimbrado);
 
             using (WsVerificaXmlRiClient cliente = new WsVerificaXmlRiClient())
             {


### PR DESCRIPTION
## Summary
- handle XML bytes using UTF-8 instead of ASCII

## Testing
- `dotnet build HG.CFDI.API.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684877b3a788832fabb05b3531fedf90