### PR TITLE
Remove unused json serialization

### DIFF
--- a/HG.CFDI.SERVICE/Services/CartaPorteService.cs
+++ b/HG.CFDI.SERVICE/Services/CartaPorteService.cs
@@ -438,9 +438,6 @@ namespace HG.CFDI.SERVICE.Services
                     return respuesta;
                 }
 
-                //serialize json
-                var json_request = JsonConvert.SerializeObject(requestUnique.request);
-
                 var client = new EmisionServiceClient();
 
                 BuzonE.responseBE responseServicio = new BuzonE.responseBE();


### PR DESCRIPTION
## Summary
- clean up `CartaPorteService` by removing a leftover serialization step

## Testing
- `dotnet format` *(fails: command not found)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684877950ff4832fa3f1666d6fba3a62