### PR TITLE
Update timbrado enum usage

### DIFF
--- a/HG.CFDI.CORE/Models/SistemaTimbrado.cs
+++ b/HG.CFDI.CORE/Models/SistemaTimbrado.cs
@@ -1,0 +1,9 @@
+namespace HG.CFDI.CORE.Models
+{
+    public enum SistemaTimbrado
+    {
+        Lis = 1,
+        BuzonE = 2,
+        InvoiceOne = 3
+    }
+}

--- a/Jobs/TransferenciaCartaPorte/CartaPorteSender.cs
+++ b/Jobs/TransferenciaCartaPorte/CartaPorteSender.cs
@@ -65,15 +65,15 @@ namespace HG.CFDI.API.Jobs.TransferenciaCartaPorte
                             await cartaPorteService.deleteErrors(cp.no_guia, cp.compania);
                             try
                             {
-                                switch (cp.sistemaTimbrado)
+                                switch ((SistemaTimbrado)cp.sistemaTimbrado)
                                 {
-                                    case 1:
+                                    case SistemaTimbrado.Lis:
                                         await cartaPorteService.timbrarConLis(cartaPorteServiceApi, cp);
                                         break;
-                                    case 2:
+                                    case SistemaTimbrado.BuzonE:
                                         await cartaPorteService.timbrarConBuzonE(cp, compania.Database);
                                         break;
-                                    case 3:
+                                    case SistemaTimbrado.InvoiceOne:
                                         await cartaPorteService.timbrarConInvoiceOne(cp, compania.Database);
                                         break;
                                     default:


### PR DESCRIPTION
## Summary
- add `SistemaTimbrado` enum
- use enum in `TimbraRemision` endpoint
- update controller validation and switch statements
- update job switch to enum

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a05c6518832fb84ce38dad3e531c