### PR TITLE
Handle failure when saving BuzonE documents

### DIFF
--- a/HG.CFDI.SERVICE/Services/CartaPorteService.cs
+++ b/HG.CFDI.SERVICE/Services/CartaPorteService.cs
@@ -467,7 +467,15 @@ namespace HG.CFDI.SERVICE.Services
 
                 if (respuesta.IsSuccess)
                 {
-                    await PersistirDocumentosAsync(cartaPorte, respuesta.XmlByteArray, respuesta.PdfByteArray, responseServicio.uuid, database);
+                    try
+                    {
+                        await PersistirDocumentosAsync(cartaPorte, respuesta.XmlByteArray, respuesta.PdfByteArray, responseServicio.uuid, database);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        _logger.LogError(ex, "Error persisting stamped documents");
+                        await insertError(cartaPorte.no_guia, cartaPorte.num_guia, cartaPorte.compania, ex.Message, null, null, null);
+                    }
                 }
 
                 return respuesta;


### PR DESCRIPTION
## Summary
- wrap PersistirDocumentosAsync call in timbrarConBuzonE with its own try/catch
- log the error and insert DB record if saving docs fails

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a537a310832f827cd9b82622ea54