### PR TITLE
Use fire-and-forget for document persistence

### DIFF
--- a/HG.CFDI.SERVICE/Services/CartaPorteService.cs
+++ b/HG.CFDI.SERVICE/Services/CartaPorteService.cs
@@ -467,7 +467,15 @@ namespace HG.CFDI.SERVICE.Services
 
                 if (respuesta.IsSuccess)
                 {
-                    await PersistirDocumentosAsync(cartaPorte, respuesta.XmlByteArray, respuesta.PdfByteArray, responseServicio.uuid, database);
+                    _ = Task.Run(async () =>
+                    {
+                        try { await PersistirDocumentosAsync(cartaPorte, respuesta.XmlByteArray, respuesta.PdfByteArray, responseServicio.uuid, database); }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Error en procesos posteriores para {Guia}", cartaPorte.num_guia);
+                            await insertError(cartaPorte.no_guia, cartaPorte.num_guia, cartaPorte.compania, ex.Message, null, null, null);
+                        }
+                    });
                 }
 
                 return respuesta;


### PR DESCRIPTION
## Summary
- make `timbrarConBuzonE` persist documents in a background task

## Testing
- `dotnet build HG.CFDI.API.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848a53a00c0832fa9d79c5821bf3c16