### PR TITLE
Fix service client closing

### DIFF
--- a/HG.CFDI.SERVICE/Services/CartaPorteService.cs
+++ b/HG.CFDI.SERVICE/Services/CartaPorteService.cs
@@ -443,12 +443,10 @@ namespace HG.CFDI.SERVICE.Services
                     try
                     {
                         responseServicio = await client.emitirFacturaAsync(requestUnique.request);
-                        client.Close();
                     }
-                    catch
+                    finally
                     {
-                        client.Abort();
-                        throw;
+                        try { await client.CloseAsync(); } catch { client.Abort(); }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- close EmisionServiceClient with `CloseAsync` in a `finally` block

## Testing
- `dotnet build HG.CFDI.API.sln` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848a53dd8a0832f9c251eb0feafb605