### PR TITLE
Add TaskHelper.RunSafeAsync helper

### DIFF
--- a/HG.CFDI.SERVICE/Services/CartaPorteService.cs
+++ b/HG.CFDI.SERVICE/Services/CartaPorteService.cs
@@ -16,6 +16,7 @@ using System.Xml.Linq;
 using System.Globalization;
 using XSDToXML.Utils;
 using Microsoft.Extensions.Logging;
+using HG.CFDI.SERVICE.Utils;
 
 //VERSION PROD
 using static InvoiceOne.ioTimbreCFDISoapClient;
@@ -467,7 +468,11 @@ namespace HG.CFDI.SERVICE.Services
 
                 if (respuesta.IsSuccess)
                 {
-                    await PersistirDocumentosAsync(cartaPorte, respuesta.XmlByteArray, respuesta.PdfByteArray, responseServicio.uuid, database);
+                    TaskHelper.RunSafeAsync(() => PersistirDocumentosAsync(cartaPorte,
+                        respuesta.XmlByteArray,
+                        respuesta.PdfByteArray,
+                        responseServicio.uuid,
+                        database));
                 }
 
                 return respuesta;

--- a/HG.CFDI.SERVICE/Utils/TaskHelper.cs
+++ b/HG.CFDI.SERVICE/Utils/TaskHelper.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace HG.CFDI.SERVICE.Utils
+{
+    public static class TaskHelper
+    {
+        public static async Task RunSafeAsync(Func<Task> task)
+        {
+            try
+            {
+                await task();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Unhandled exception in background task");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `TaskHelper` utility with `RunSafeAsync`
- safely persist carta porte documents in background

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a543578c832fb9b85f21ddd9ef5a