### PR TITLE
Handle no response from BuzonE

### DIFF
--- a/HG.CFDI.DATA/Repositories/CartaPorteRepository.cs
+++ b/HG.CFDI.DATA/Repositories/CartaPorteRepository.cs
@@ -90,7 +90,14 @@ namespace HG.CFDI.DATA.Repositories
                         entidad.estatusTimbrado = EstatusTimbrado;
                         entidad.mensajeTimbrado = mensajeTimbrado;
                         entidad.sistemaTimbrado = sistemaTimbrado;
-                        entidad.fechaTimbrado = DateTime.Now;
+                        if (EstatusTimbrado == 5)
+                        {
+                            entidad.fechaTimbrado = null;
+                        }
+                        else
+                        {
+                            entidad.fechaTimbrado = DateTime.Now;
+                        }
 
                         // Guarda los cambios en la base de datos
                         await context.SaveChangesAsync();

--- a/HG.CFDI.SERVICE/Services/CartaPorteService.cs
+++ b/HG.CFDI.SERVICE/Services/CartaPorteService.cs
@@ -435,6 +435,18 @@ namespace HG.CFDI.SERVICE.Services
                     {
                         responseServicio = await client.emitirFacturaAsync(requestUnique.request);
                     }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error al invocar emitirFacturaAsync");
+                        TaskHelper.RunSafeAsync(() => changeStatusCartaPorteAsync(cartaPorte.no_guia, cartaPorte.num_guia, cartaPorte.compania, 5, "Sin respuesta de BuzonE", cartaPorte.sistemaTimbrado));
+                        TaskHelper.RunSafeAsync(() => insertError(cartaPorte.no_guia, cartaPorte.num_guia, cartaPorte.compania, ex.Message, null, null, null));
+                        return new UniqueResponse
+                        {
+                            IsSuccess = false,
+                            Mensaje = "No se obtuvo respuesta del servicio de timbrado.",
+                            Errores = new List<string> { ex.Message }
+                        };
+                    }
                     finally
                     {
                         try { await client.CloseAsync(); } catch { client.Abort(); }
@@ -443,6 +455,7 @@ namespace HG.CFDI.SERVICE.Services
 
                 if (responseServicio == null || string.IsNullOrWhiteSpace(responseServicio.code))
                 {
+                    TaskHelper.RunSafeAsync(() => changeStatusCartaPorteAsync(cartaPorte.no_guia, cartaPorte.num_guia, cartaPorte.compania, 5, "Sin respuesta de BuzonE", cartaPorte.sistemaTimbrado));
                     TaskHelper.RunSafeAsync(() => insertError(cartaPorte.no_guia, cartaPorte.num_guia, cartaPorte.compania, "Respuesta nula o inválida del servicio BuzónE.", null, null, null));
                     return new UniqueResponse
                     {


### PR DESCRIPTION
## Summary
- set `fechaTimbrado` to `null` when status is 5
- mark CartaPorte as status 5 when `emitirFacturaAsync` fails

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b79f41c8832fac16bd51b4a43a76