### PR TITLE
Add RetryOptions model

### DIFF
--- a/HG.CFDI.CORE/Models/AppsettingsModel.cs
+++ b/HG.CFDI.CORE/Models/AppsettingsModel.cs
@@ -65,10 +65,5 @@ namespace HG.CFDI.CORE.Models
         public string PdfPath { get; set; }
     }
 
-    public class RetryOptions
-    {
-        public int MaxEmitirFacturaRetries { get; set; } = 3;
-    }
-
 
 }

--- a/HG.CFDI.CORE/Models/RetryOptions.cs
+++ b/HG.CFDI.CORE/Models/RetryOptions.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace HG.CFDI.CORE.Models
+{
+    public class RetryOptions
+    {
+        public int MaxEmitirFacturaRetries { get; set; } = 3;
+    }
+}

--- a/HG.CFDI.SERVICE/HG.CFDI.SERVICE.csproj
+++ b/HG.CFDI.SERVICE/HG.CFDI.SERVICE.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="CFDI.BuildPdf" Version="1.0.2" />
     <PackageReference Include="Interceptor.AOP.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="6.0.0" />
     <PackageReference Include="System.ServiceModel.Federation" Version="6.2.0" />


### PR DESCRIPTION
## Summary
- move RetryOptions class out of AppsettingsModel.cs
- create HG.CFDI.CORE/Models/RetryOptions.cs
- reference Serilog in HG.CFDI.SERVICE so build compiles

## Testing
- `dotnet build HG.CFDI.API.sln -c Release -p:NoWarn=NU1605`

------
https://chatgpt.com/codex/tasks/task_e_6848c0c8d4dc832fb958e79c255654d0