### PR TITLE
Refactor persistence tasks

### DIFF
--- a/HG.CFDI.SERVICE/Services/Timbrado/Documentos/DocumentosService.cs
+++ b/HG.CFDI.SERVICE/Services/Timbrado/Documentos/DocumentosService.cs
@@ -78,9 +78,17 @@ namespace HG.CFDI.SERVICE.Services.Timbrado.Documentos
             {
                 var servidores = new[] { "server2019", "server2008" };
 
-                foreach (var server in servidores)
+                var tareas = servidores.Select(async server =>
                 {
-                    var success = await _cartaPorteRepository.InsertDocumentosTimbrados(archivo, server);
+                    bool success = false;
+                    try
+                    {
+                        success = await _cartaPorteRepository.InsertDocumentosTimbrados(archivo, server);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, $"Error insertando documentos en {server}");
+                    }
 
                     if (!success)
                     {
@@ -89,7 +97,11 @@ namespace HG.CFDI.SERVICE.Services.Timbrado.Documentos
 
                         //await insertError(cartaPorte.no_guia, cartaPorte.num_guia, cartaPorte.compania, msg, null, null, null);
                     }
-                }
+
+                    return success;
+                });
+
+                await Task.WhenAll(tareas);
             }
             catch (System.Exception ex)
             {


### PR DESCRIPTION
## Summary
- parallelize document persistence using tasks
- await both DB inserts concurrently for CartaPorte

## Testing
- `dotnet build HG.CFDI.API.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e8592c54832f9ae255ae7c19f3f4