### PR TITLE
Add initial unit tests

### DIFF
--- a/HG.CFDI.API.sln
+++ b/HG.CFDI.API.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ryder.Api.Client", "libs\Ry
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CFDI.Data", "libs\Cfdi.Data\CFDI.Data.csproj", "{7D97682C-AA6B-8054-2CEB-1D395A09C359}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HG.CFDI.Tests", "HG.CFDI.Tests\HG.CFDI.Tests.csproj", "{77456A52-7583-465C-9594-E2FDACBBFA47}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{7D97682C-AA6B-8054-2CEB-1D395A09C359}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D97682C-AA6B-8054-2CEB-1D395A09C359}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D97682C-AA6B-8054-2CEB-1D395A09C359}.Release|Any CPU.Build.0 = Release|Any CPU
+                {77456A52-7583-465C-9594-E2FDACBBFA47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {77456A52-7583-465C-9594-E2FDACBBFA47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {77456A52-7583-465C-9594-E2FDACBBFA47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {77456A52-7583-465C-9594-E2FDACBBFA47}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HG.CFDI.Tests/HG.CFDI.Tests.csproj
+++ b/HG.CFDI.Tests/HG.CFDI.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HG.CFDI.CORE\HG.CFDI.CORE.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HG.CFDI.Tests/Utilities/QueryableExtensionsTests.cs
+++ b/HG.CFDI.Tests/Utilities/QueryableExtensionsTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using HG.CFDI.CORE.Utilities;
+using Xunit;
+
+namespace HG.CFDI.Tests.Utilities
+{
+    public class QueryableExtensionsTests
+    {
+        private class TestItem
+        {
+            public string Name { get; set; } = string.Empty;
+            public int Age { get; set; }
+        }
+
+        [Fact]
+        public void OrderByDynamic_SortsByPrimaryAndSecondary()
+        {
+            var data = new List<TestItem>
+            {
+                new TestItem { Name = "Bob", Age = 30 },
+                new TestItem { Name = "Ana", Age = 20 },
+                new TestItem { Name = "Bob", Age = 25 }
+            };
+
+            var result = data.AsQueryable()
+                              .OrderByDynamic("Name", false, "Age", true)
+                              .ToList();
+
+            Assert.Equal(new[] { "Ana", "Bob", "Bob" }, result.Select(x => x.Name).ToArray());
+            Assert.Equal(new[] { 20, 30, 25 }, result.Select(x => x.Age).ToArray());
+        }
+    }
+}

--- a/HG.CFDI.Tests/Utilities/TransformDataTests.cs
+++ b/HG.CFDI.Tests/Utilities/TransformDataTests.cs
@@ -1,0 +1,25 @@
+using HG.CFDI.CORE.Utilities;
+using Xunit;
+
+namespace HG.CFDI.Tests.Utilities
+{
+    public class TransformDataTests
+    {
+        [Theory]
+        [InlineData("Árbol número ñandú", "Arbol numero nandu")]
+        [InlineData("", "")]
+        public void RemoverAcentos_RemovesDiacritics(string input, string expected)
+        {
+            var result = TransformData.RemoverAcentos(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void RemoverAcentos_NullInput_ReturnsNull()
+        {
+            string? input = null;
+            var result = TransformData.RemoverAcentos(input);
+            Assert.Null(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set up new `HG.CFDI.Tests` project with xUnit
- cover `TransformData.RemoverAcentos` and `QueryableExtensions.OrderByDynamic`
- include tests project in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ea1538f8832fbd80e93f49380427