### PR TITLE
Add liquidacion timbrado endpoint

### DIFF
--- a/Controllers/LiquidacionController.cs
+++ b/Controllers/LiquidacionController.cs
@@ -1,0 +1,39 @@
+using HG.CFDI.CORE.Interfaces;
+using HG.CFDI.CORE.Models.DtoLiquidacionCfdi;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HG.CFDI.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class LiquidacionController : ControllerBase
+    {
+        private readonly ILiquidacionService _liquidacionService;
+        private readonly ILogger<LiquidacionController> _logger;
+
+        public LiquidacionController(ILogger<LiquidacionController> logger, ILiquidacionService liquidacionService)
+        {
+            _logger = logger;
+            _liquidacionService = liquidacionService;
+        }
+
+        [HttpGet("TimbrarLiquidacion")]
+        public async Task<IActionResult> TimbrarLiquidacion(string database, int noLiquidacion)
+        {
+            try
+            {
+                var liquidacion = await _liquidacionService.ObtenerLiquidacion(database.ToLower(), noLiquidacion);
+                if (liquidacion == null)
+                {
+                    return NotFound();
+                }
+                return Ok(liquidacion);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error al obtener la liquidación");
+                return StatusCode(500, "Internal server error");
+            }
+        }
+    }
+}

--- a/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace HG.CFDI.CORE.Interfaces
+{
+    public interface ILiquidacionRepository
+    {
+        Task<string?> ObtenerDatosNominaJson(string database, int noLiquidacion);
+    }
+}

--- a/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using HG.CFDI.CORE.Models.DtoLiquidacionCfdi;
+
+namespace HG.CFDI.CORE.Interfaces
+{
+    public interface ILiquidacionService
+    {
+        Task<CfdiNomina?> ObtenerLiquidacion(string database, int noLiquidacion);
+    }
+}

--- a/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
+++ b/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
@@ -1,0 +1,57 @@
+using HG.CFDI.CORE.ContextFactory;
+using HG.CFDI.CORE.Interfaces;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using CFDI.Data.Contexts;
+using System.Data;
+
+namespace HG.CFDI.DATA.Repositories
+{
+    public class LiquidacionRepository : ILiquidacionRepository
+    {
+        private readonly IDbContextFactory _dbContextFactory;
+        private readonly ILogger<LiquidacionRepository> _logger;
+
+        public LiquidacionRepository(IDbContextFactory dbContextFactory, ILogger<LiquidacionRepository> logger)
+        {
+            _dbContextFactory = dbContextFactory;
+            _logger = logger;
+        }
+
+        public async Task<string?> ObtenerDatosNominaJson(string database, int noLiquidacion)
+        {
+            string server = database switch
+            {
+                "hgdb_lis" => "server2019",
+                "chdb_lis" => "server2008",
+                "rldb_lis" => "server2008",
+                "lindadb" => "server2008",
+                _ => "server2019"
+            };
+
+            var options = _dbContextFactory.CreateDbContextOptions(server);
+            using var context = new CfdiDbContext(options);
+            using var command = context.Database.GetDbConnection().CreateCommand();
+            command.CommandText = "cfdi.obtenerDatosNominaJSON";
+            command.CommandType = CommandType.StoredProcedure;
+            command.Parameters.Add(new SqlParameter("@Database", database));
+            command.Parameters.Add(new SqlParameter("@NoLiquidacion", noLiquidacion));
+
+            await context.Database.OpenConnectionAsync();
+            try
+            {
+                using var reader = await command.ExecuteReaderAsync();
+                if (await reader.ReadAsync())
+                {
+                    return reader.IsDBNull(0) ? null : reader.GetString(0);
+                }
+                return null;
+            }
+            finally
+            {
+                await context.Database.CloseConnectionAsync();
+            }
+        }
+    }
+}

--- a/HG.CFDI.SERVICE/Services/LiquidacionService.cs
+++ b/HG.CFDI.SERVICE/Services/LiquidacionService.cs
@@ -1,0 +1,31 @@
+using HG.CFDI.CORE.Interfaces;
+using HG.CFDI.CORE.Models.DtoLiquidacionCfdi;
+using System.Text.Json;
+
+namespace HG.CFDI.SERVICE.Services
+{
+    public class LiquidacionService : ILiquidacionService
+    {
+        private readonly ILiquidacionRepository _repository;
+
+        public LiquidacionService(ILiquidacionRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<CfdiNomina?> ObtenerLiquidacion(string database, int noLiquidacion)
+        {
+            var json = await _repository.ObtenerDatosNominaJson(database, noLiquidacion);
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+            try
+            {
+                return JsonSerializer.Deserialize<CfdiNomina>(json);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -75,6 +75,8 @@ builder.Services.AddScoped<ICartaPorteServiceApi, CartaPorteServiceApi>();
 builder.Services.AddScoped<IRyderApiClient, RyderApiClient>();
 builder.Services.AddScoped<ITipoCambioService, TipoCambioService>();
 builder.Services.AddScoped<ITipoCambioRepository, TipoCambioRepository>();
+builder.Services.AddScoped<ILiquidacionService, LiquidacionService>();
+builder.Services.AddScoped<ILiquidacionRepository, LiquidacionRepository>();
 
 //Appsettings
 builder.Services.Configure<List<FirmaDigitalOptions>>(builder.Configuration.GetSection("FirmaDigital"));


### PR DESCRIPTION
## Summary
- create DTO service and repository interfaces for liquidaciones
- add LiquidacionService and LiquidacionRepository implementations
- register new services in Program.cs
- expose `TimbrarLiquidacion` endpoint in new LiquidacionController

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c94061a14832f8c31ca08cd1b8afd