### PR TITLE
Add liquidacion timbrado endpoint

### DIFF
--- a/Controllers/LiquidacionController.cs
+++ b/Controllers/LiquidacionController.cs
@@ -17,8 +17,8 @@ namespace HG.CFDI.API.Controllers
             _liquidacionService = liquidacionService;
         }
 
-        [HttpGet("TimbrarLiquidacion")]
-        public async Task<IActionResult> TimbrarLiquidacion(string database, int noLiquidacion)
+        [HttpGet("GetLiquidacion")]
+        public async Task<IActionResult> GetLiquidacion(string database, int noLiquidacion)
         {
             try
             {
@@ -32,6 +32,21 @@ namespace HG.CFDI.API.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error al obtener la liquidación");
+                return StatusCode(500, "Internal server error");
+            }
+        }
+
+        [HttpPost("TimbrarLiquidacion")]
+        public async Task<IActionResult> TimbrarLiquidacion(string database, int noLiquidacion)
+        {
+            try
+            {
+                var response = await _liquidacionService.TimbrarLiquidacionAsync(database.ToLower(), noLiquidacion);
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error al timbrar la liquidación");
                 return StatusCode(500, "Internal server error");
             }
         }

--- a/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
@@ -5,5 +5,9 @@ namespace HG.CFDI.CORE.Interfaces
     public interface ILiquidacionRepository
     {
         Task<string?> ObtenerDatosNominaJson(string database, int noLiquidacion);
+
+        Task ActualizarEstatusAsync(string database, int noLiquidacion, int estatus);
+
+        Task InsertarHistoricoAsync(string database, int noLiquidacion, int estatus, byte[]? xmlTimbrado, byte[]? pdfTimbrado, string? uuid);
     }
 }

--- a/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using HG.CFDI.CORE.Models.DtoLiquidacionCfdi;
 using BuzonE;
+using HG.CFDI.CORE.Models;
 
 namespace HG.CFDI.CORE.Interfaces
 {
@@ -8,5 +9,7 @@ namespace HG.CFDI.CORE.Interfaces
     {
         Task<CfdiNomina?> ObtenerLiquidacion(string database, int noLiquidacion);
         Task<BuzonE.RequestBE> ConstruirRequestBuzonEAsync(CfdiNomina liquidacion, string database);
+
+        Task<UniqueResponse> TimbrarLiquidacionAsync(string database, int noLiquidacion);
     }
 }

--- a/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
+++ b/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
@@ -53,5 +53,70 @@ namespace HG.CFDI.DATA.Repositories
                 await context.Database.CloseConnectionAsync();
             }
         }
+
+        public async Task ActualizarEstatusAsync(string database, int noLiquidacion, int estatus)
+        {
+            string server = database switch
+            {
+                "hgdb_lis" => "server2019",
+                "chdb_lis" => "server2008",
+                "rldb_lis" => "server2008",
+                "lindadb" => "server2008",
+                _ => "server2019"
+            };
+
+            var options = _dbContextFactory.CreateDbContextOptions(server);
+            using var context = new CfdiDbContext(options);
+            using var command = context.Database.GetDbConnection().CreateCommand();
+            command.CommandText = "cfdi.actualizaEstatusLiquidacionOperador";
+            command.CommandType = CommandType.StoredProcedure;
+            command.Parameters.Add(new SqlParameter("@Database", database));
+            command.Parameters.Add(new SqlParameter("@NoLiquidacion", noLiquidacion));
+            command.Parameters.Add(new SqlParameter("@Estatus", estatus));
+
+            await context.Database.OpenConnectionAsync();
+            try
+            {
+                await command.ExecuteNonQueryAsync();
+            }
+            finally
+            {
+                await context.Database.CloseConnectionAsync();
+            }
+        }
+
+        public async Task InsertarHistoricoAsync(string database, int noLiquidacion, int estatus, byte[]? xmlTimbrado, byte[]? pdfTimbrado, string? uuid)
+        {
+            string server = database switch
+            {
+                "hgdb_lis" => "server2019",
+                "chdb_lis" => "server2008",
+                "rldb_lis" => "server2008",
+                "lindadb" => "server2008",
+                _ => "server2019"
+            };
+
+            var options = _dbContextFactory.CreateDbContextOptions(server);
+            using var context = new CfdiDbContext(options);
+            using var command = context.Database.GetDbConnection().CreateCommand();
+            command.CommandText = "cfdi.insertLiquidacionOperadorHist";
+            command.CommandType = CommandType.StoredProcedure;
+            command.Parameters.Add(new SqlParameter("@Database", database));
+            command.Parameters.Add(new SqlParameter("@NoLiquidacion", noLiquidacion));
+            command.Parameters.Add(new SqlParameter("@Estatus", estatus));
+            command.Parameters.Add(new SqlParameter("@XmlTimbrado", SqlDbType.VarBinary) { Value = (object?)xmlTimbrado ?? DBNull.Value });
+            command.Parameters.Add(new SqlParameter("@PdfTimbrado", SqlDbType.VarBinary) { Value = (object?)pdfTimbrado ?? DBNull.Value });
+            command.Parameters.Add(new SqlParameter("@Uuid", SqlDbType.VarChar) { Value = (object?)uuid ?? DBNull.Value });
+
+            await context.Database.OpenConnectionAsync();
+            try
+            {
+                await command.ExecuteNonQueryAsync();
+            }
+            finally
+            {
+                await context.Database.CloseConnectionAsync();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- create new LiquidacionService method to orchestrate timbrado
- extend liquidacion repositories and interfaces
- implement API endpoint `TimbrarLiquidacion`

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: BuzonE namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb1c49628832f847294f8eea2f281