### PR TITLE
Move liquidacion logic to service layer

### DIFF
--- a/HG.CFDI.SERVICE/Services/LiquidacionService.cs
+++ b/HG.CFDI.SERVICE/Services/LiquidacionService.cs
@@ -55,6 +55,7 @@ namespace HG.CFDI.SERVICE.Services
 
             var request = await _validacionesNominaSat.ConstruirRequestBuzonEAsync(liquidacion, database);
 
+            string liquidacionJson = JsonSerializer.Serialize(liquidacion);
             await _repository.InsertarHistoricoAsync(database, noLiquidacion, liquidacionJson);
 
             try


### PR DESCRIPTION
## Summary
- refactor LiquidacionRepository to avoid stored procedure calls
- update service to serialize JSON before saving history

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684efdd7790c832fad3642d305ed981c