### PR TITLE
Update liquidacion service to accept company id

### DIFF
--- a/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
@@ -6,7 +6,7 @@ namespace HG.CFDI.CORE.Interfaces
 {
     public interface ILiquidacionService
     {
-        Task<CfdiNomina?> ObtenerLiquidacion(string database, int noLiquidacion);
-        Task<UniqueResponse> TimbrarLiquidacionAsync(string database, int noLiquidacion);
+        Task<CfdiNomina?> ObtenerLiquidacion(int idCompania, int noLiquidacion);
+        Task<UniqueResponse> TimbrarLiquidacionAsync(int idCompania, int noLiquidacion);
     }
 }


### PR DESCRIPTION
## Summary
- map database string to company ID in `GetLiquidacion`
- update controller to forward `idCompania` directly when timbrando
- adapt `ILiquidacionService` and `LiquidacionService` to work with `idCompania`

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4a7e13f4832fbaec4c15c75ca8d8