### PR TITLE
Add logging for liquidacion processes

### DIFF
--- a/HG.CFDI.DATA/Repositories/CartaPorteRepository.cs
+++ b/HG.CFDI.DATA/Repositories/CartaPorteRepository.cs
@@ -101,8 +101,9 @@ namespace HG.CFDI.DATA.Repositories
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Error changeStatusCartaPorteAsync no_guia:{NoGuia} compania:{Compania}", no_guia, compania);
                 throw;
             }
         }

--- a/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
+++ b/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
@@ -23,6 +23,7 @@ namespace HG.CFDI.DATA.Repositories
 
         public async Task<string?> ObtenerDatosNominaJson(string database, int idLiquidacion)
         {
+            _logger.LogInformation("Inicio ObtenerDatosNominaJson Database:{Database} Liquidacion:{IdLiquidacion}", database, idLiquidacion);
             string server = database switch
             {
                 "hgdb_lis" => "server2019",
@@ -46,8 +47,11 @@ namespace HG.CFDI.DATA.Repositories
                 using var reader = await command.ExecuteReaderAsync();
                 if (await reader.ReadAsync())
                 {
-                    return reader.IsDBNull(0) ? null : reader.GetString(0);
+                    var result = reader.IsDBNull(0) ? null : reader.GetString(0);
+                    _logger.LogInformation("Fin ObtenerDatosNominaJson Database:{Database} Liquidacion:{IdLiquidacion}", database, idLiquidacion);
+                    return result;
                 }
+                _logger.LogInformation("Fin ObtenerDatosNominaJson Database:{Database} Liquidacion:{IdLiquidacion}", database, idLiquidacion);
                 return null;
             }
             finally
@@ -58,17 +62,21 @@ namespace HG.CFDI.DATA.Repositories
 
         public async Task<liquidacionOperador?> ObtenerCabeceraAsync(int idCompania, int idLiquidacion)
         {
+            _logger.LogInformation("Inicio ObtenerCabeceraAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
             string server = "server2019";
 
             var options = _dbContextFactory.CreateDbContextOptions(server);
             using var context = new CfdiDbContext(options);
 
-            return await context.liquidacionOperadors
+            var result = await context.liquidacionOperadors
                 .FirstOrDefaultAsync(l => l.IdLiquidacion == idLiquidacion && l.IdCompania == idCompania);
+            _logger.LogInformation("Fin ObtenerCabeceraAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
+            return result;
         }
 
         public async Task RegistrarInicioIntentoAsync(int idCompania, int idLiquidacion, byte estatus, string liquidacionJson)
         {
+            _logger.LogInformation("Inicio RegistrarInicioIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
             string server = "server2019";
 
             var options = _dbContextFactory.CreateDbContextOptions(server);
@@ -112,16 +120,19 @@ namespace HG.CFDI.DATA.Repositories
 
                     await transaction.CommitAsync();
                 }
-                catch
+                catch (Exception ex)
                 {
                     await transaction.RollbackAsync();
+                    _logger.LogError(ex, "Error RegistrarInicioIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
                     throw;
                 }
             });
+            _logger.LogInformation("Fin RegistrarInicioIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
         }
 
         public async Task ActualizarResultadoIntentoAsync(int idCompania, int idLiquidacion, byte estatus, DateTime? fechaProximoIntento = null)
         {
+            _logger.LogInformation("Inicio ActualizarResultadoIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
             string server = "server2019";
 
             var options = _dbContextFactory.CreateDbContextOptions(server);
@@ -131,7 +142,10 @@ namespace HG.CFDI.DATA.Repositories
                 .FirstOrDefaultAsync(l => l.IdLiquidacion == idLiquidacion && l.IdCompania == idCompania);
 
             if (entidad is null)
+            {
+                _logger.LogInformation("Fin ActualizarResultadoIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
                 throw new InvalidOperationException("Liquidacion no encontrada.");
+            }
 
             entidad.Estatus = estatus;
             entidad.FechaProximoIntento = fechaProximoIntento;
@@ -147,10 +161,12 @@ namespace HG.CFDI.DATA.Repositories
                 historico.EstadoIntento = ObtenerNombreEstado(estatus);
                 await context.SaveChangesAsync();
             }
+            _logger.LogInformation("Fin ActualizarResultadoIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
         }
 
         public async Task InsertarDocTimbradoLiqAsync(int idCompania, int idLiquidacion, byte[]? xmlTimbrado, byte[]? pdfTimbrado, string? uuid)
         {
+            _logger.LogInformation("Inicio InsertarDocTimbradoLiqAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
             string server = "server2019";
 
             var options = _dbContextFactory.CreateDbContextOptions(server);
@@ -166,6 +182,7 @@ namespace HG.CFDI.DATA.Repositories
                 entidad.UUID = uuid;
                 await context.SaveChangesAsync();
             }
+            _logger.LogInformation("Fin InsertarDocTimbradoLiqAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
         }
 
         public string ObtenerNombreEstado(byte estatus) => estatus switch

--- a/HG.CFDI.SERVICE/Services/LiquidacionService.cs
+++ b/HG.CFDI.SERVICE/Services/LiquidacionService.cs
@@ -17,34 +17,47 @@ namespace HG.CFDI.SERVICE.Services
     {
         private readonly ILiquidacionRepository _repository;
         private readonly IValidacionesNominaSatService _validacionesNominaSat;
+        private readonly ILogger<LiquidacionService> _logger;
 
-        public LiquidacionService(IValidacionesNominaSatService validacionesNominaSat, ILiquidacionRepository repository, IOptions<List<BuzonEApiCredential>> buzonEOptions)
+        public LiquidacionService(IValidacionesNominaSatService validacionesNominaSat, ILiquidacionRepository repository, IOptions<List<BuzonEApiCredential>> buzonEOptions, ILogger<LiquidacionService> logger)
         {
             _repository = repository;
             _validacionesNominaSat = validacionesNominaSat;
+            _logger = logger;
         }
 
         public async Task<CfdiNomina?> ObtenerLiquidacion(int idCompania, int noLiquidacion)
         {
+            _logger.LogInformation("Inicio ObtenerLiquidacion Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
             string? database = ObtenerDatabase(idCompania);
             if (string.IsNullOrEmpty(database))
+            {
+                _logger.LogInformation("Fin ObtenerLiquidacion Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
                 return null;
+            }
 
             var json = await _repository.ObtenerDatosNominaJson(database, noLiquidacion);
             if (string.IsNullOrWhiteSpace(json))
+            {
+                _logger.LogInformation("Fin ObtenerLiquidacion Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
                 return null;
+            }
             try
             {
-                return JsonSerializer.Deserialize<CfdiNomina>(json);
+                var result = JsonSerializer.Deserialize<CfdiNomina>(json);
+                _logger.LogInformation("Fin ObtenerLiquidacion Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
+                return result;
             }
             catch
             {
+                _logger.LogInformation("Fin ObtenerLiquidacion Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
                 return null;
             }
         }
      
         public async Task<UniqueResponse> TimbrarLiquidacionAsync(int idCompania, int noLiquidacion)
         {
+            _logger.LogInformation("Inicio TimbrarLiquidacionAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
             var respuesta = new UniqueResponse();
 
             var cabecera = await _repository.ObtenerCabeceraAsync(idCompania, noLiquidacion);
@@ -52,6 +65,7 @@ namespace HG.CFDI.SERVICE.Services
             {
                 respuesta.IsSuccess = false;
                 respuesta.Mensaje = "La liquidación ya fue timbrada";
+                _logger.LogInformation("Fin TimbrarLiquidacionAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
                 return respuesta;
             }
 
@@ -62,6 +76,7 @@ namespace HG.CFDI.SERVICE.Services
             {
                 respuesta.IsSuccess = false;
                 respuesta.Mensaje = "Liquidación no encontrada";
+                _logger.LogInformation("Fin TimbrarLiquidacionAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
                 return respuesta;
             }
 
@@ -116,6 +131,7 @@ namespace HG.CFDI.SERVICE.Services
                 respuesta.Errores.Add(ex.Message);
             }
 
+            _logger.LogInformation("Fin TimbrarLiquidacionAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, noLiquidacion);
             return respuesta;
         }
 


### PR DESCRIPTION
## Summary
- inject logger into `LiquidacionService`
- log start and end of LiquidacionService methods
- log start and end of LiquidacionRepository methods
- log error details before rethrowing

## Testing
- `dotnet build HG.CFDI.API.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f71e7d994832f8a56a2f6a40f6e11