### PR TITLE
Implement error logging for liquidacion

### DIFF
--- a/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
@@ -14,5 +14,7 @@ namespace HG.CFDI.CORE.Interfaces
         Task RegistrarInicioIntentoAsync(int idCompania, int idLiquidacion, byte estatus, string liquidacionJson);
 
         Task ActualizarResultadoIntentoAsync(int idCompania, int idLiquidacion, byte estatus, DateTime? fechaProximoIntento = null);
+
+        Task RegistrarErrorIntentoAsync(int idCompania, int idLiquidacion, short numeroIntento, string error);
     }
 }

--- a/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
+++ b/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
@@ -168,6 +168,31 @@ namespace HG.CFDI.DATA.Repositories
             }
         }
 
+        public async Task RegistrarErrorIntentoAsync(int idCompania, int idLiquidacion, short numeroIntento, string error)
+        {
+            string server = "server2019";
+
+            var options = _dbContextFactory.CreateDbContextOptions(server);
+            using var context = new CfdiDbContext(options);
+
+            var historico = await context.liquidacionOperadorHists
+                .Where(h => h.IdLiquidacion == idLiquidacion && h.IdCompania == idCompania && h.NumeroIntento == numeroIntento)
+                .OrderByDescending(h => h.IdHistorico)
+                .FirstOrDefaultAsync();
+
+            var registro = new liquidacionOperadorHistError
+            {
+                IdHistorico = historico?.IdHistorico ?? 0,
+                IdLiquidacion = idLiquidacion,
+                IdCompania = idCompania,
+                NumeroIntento = numeroIntento,
+                TextoError = error
+            };
+
+            context.liquidacionOperadorHistErrors.Add(registro);
+            await context.SaveChangesAsync();
+        }
+
         public string ObtenerNombreEstado(byte estatus) => estatus switch
         {
             0 => "Pendiente",

--- a/HG.CFDI.SERVICE/Services/LiquidacionService.cs
+++ b/HG.CFDI.SERVICE/Services/LiquidacionService.cs
@@ -101,8 +101,13 @@ namespace HG.CFDI.SERVICE.Services
                     respuesta.IsSuccess = false;
                     respuesta.Mensaje = responseServicio?.mensaje ?? "Error en timbrado";
 
+                    string mensajeError = responseServicio?.mensajeErrorTimbrado ?? respuesta.Mensaje;
                     if (!string.IsNullOrWhiteSpace(responseServicio?.mensajeErrorTimbrado))
                         respuesta.Errores.Add(responseServicio.mensajeErrorTimbrado);
+
+                    var cabeceraActual = await _repository.ObtenerCabeceraAsync(idCompania, noLiquidacion);
+                    if (cabeceraActual != null)
+                        await _repository.RegistrarErrorIntentoAsync(idCompania, noLiquidacion, cabeceraActual.UltimoIntento, mensajeError);
                 }
             }
             catch (Exception ex)
@@ -114,6 +119,10 @@ namespace HG.CFDI.SERVICE.Services
                 respuesta.IsSuccess = false;
                 respuesta.Mensaje = "Ocurrió un error al timbrar";
                 respuesta.Errores.Add(ex.Message);
+
+                var cabeceraActual = await _repository.ObtenerCabeceraAsync(idCompania, noLiquidacion);
+                if (cabeceraActual != null)
+                    await _repository.RegistrarErrorIntentoAsync(idCompania, noLiquidacion, cabeceraActual.UltimoIntento, ex.Message);
             }
 
             return respuesta;


### PR DESCRIPTION
## Summary
- add new `RegistrarErrorIntentoAsync` to `ILiquidacionRepository`
- implement `RegistrarErrorIntentoAsync` in `LiquidacionRepository`
- log PAC and exception errors in `LiquidacionService`
- run `dotnet build` to verify

## Testing
- `dotnet build HG.CFDI.API.sln`

------
https://chatgpt.com/codex/tasks/task_e_684f71d94c34832fa455b10f23c18498