### PR TITLE
Move EstatusLiquidacion enum to CORE

### DIFF
--- a/HG.CFDI.CORE/Models/EstatusLiquidacion.cs
+++ b/HG.CFDI.CORE/Models/EstatusLiquidacion.cs
@@ -1,0 +1,12 @@
+namespace HG.CFDI.CORE.Models
+{
+    public enum EstatusLiquidacion : byte
+    {
+        Pendiente = 0,
+        EnProceso = 1,
+        ErrorTransitorio = 4,
+        RequiereRevision = 2,
+        Timbrado = 3,
+        Migrada = 5
+    }
+}

--- a/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
+++ b/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
@@ -1,5 +1,6 @@
 using HG.CFDI.CORE.ContextFactory;
 using HG.CFDI.CORE.Interfaces;
+using HG.CFDI.CORE.Models;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -102,7 +103,7 @@ namespace HG.CFDI.DATA.Repositories
                         IdLiquidacion = idLiquidacion,
                         IdCompania = idCompania,
                         NumeroIntento = nuevoIntento,
-                        EstadoIntento = ObtenerNombreEstado(estatus),
+                        EstadoIntento = ObtenerNombreEstado((EstatusLiquidacion)estatus),
                         SnapshotData = liquidacionJson,
                         FechaIntento = DateTime.UtcNow
                     };
@@ -144,7 +145,7 @@ namespace HG.CFDI.DATA.Repositories
 
             if (historico != null)
             {
-                historico.EstadoIntento = ObtenerNombreEstado(estatus);
+                historico.EstadoIntento = ObtenerNombreEstado((EstatusLiquidacion)estatus);
                 await context.SaveChangesAsync();
             }
         }
@@ -168,14 +169,14 @@ namespace HG.CFDI.DATA.Repositories
             }
         }
 
-        public string ObtenerNombreEstado(byte estatus) => estatus switch
+        public string ObtenerNombreEstado(EstatusLiquidacion estatus) => estatus switch
         {
-            0 => "Pendiente",
-            1 => "EnProceso",
-            2 => "RequiereRevision",
-            3 => "Timbrado",
-            4 => "ErrorTransitorio",
-            5 => "Migrada",
+            EstatusLiquidacion.Pendiente => "Pendiente",
+            EstatusLiquidacion.EnProceso => "EnProceso",
+            EstatusLiquidacion.RequiereRevision => "RequiereRevision",
+            EstatusLiquidacion.Timbrado => "Timbrado",
+            EstatusLiquidacion.ErrorTransitorio => "ErrorTransitorio",
+            EstatusLiquidacion.Migrada => "Migrada",
             _ => "Desconocido"
         };
     }

--- a/HG.CFDI.SERVICE/Services/LiquidacionService.cs
+++ b/HG.CFDI.SERVICE/Services/LiquidacionService.cs
@@ -134,15 +134,6 @@ namespace HG.CFDI.SERVICE.Services
             await _repository.InsertarDocTimbradoLiqAsync(idCompania, noLiquidacion, null, null, null);
         }
 
-        public enum EstatusLiquidacion : byte
-        {
-            Pendiente = 0,
-            EnProceso = 1,
-            ErrorTransitorio = 4,
-            RequiereRevision = 2,
-            Timbrado = 3,
-            Migrada = 5
-        }
 
         private static string? ObtenerDatabase(int idCompania)
         {


### PR DESCRIPTION
## Summary
- add `EstatusLiquidacion` enum to CORE models
- remove local enum from `LiquidacionService`
- reference new enum in `LiquidacionRepository`

## Testing
- `dotnet build HG.CFDI.API.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f74505020832f90f33b1b88926812