### PR TITLE
Update MensajeCorto when status changes

### DIFF
--- a/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
@@ -11,9 +11,9 @@ namespace HG.CFDI.CORE.Interfaces
 
         Task<liquidacionOperador?> ObtenerCabeceraAsync(int idCompania, int idLiquidacion);
 
-        Task RegistrarInicioIntentoAsync(int idCompania, int idLiquidacion, byte estatus, string liquidacionJson);
+        Task RegistrarInicioIntentoAsync(int idCompania, int idLiquidacion, byte estatus, string liquidacionJson, string? mensajeCorto = null);
 
-        Task ActualizarResultadoIntentoAsync(int idCompania, int idLiquidacion, byte estatus, DateTime? fechaProximoIntento = null);
+        Task ActualizarResultadoIntentoAsync(int idCompania, int idLiquidacion, byte estatus, DateTime? fechaProximoIntento = null, string? mensajeCorto = null);
 
         Task RegistrarErrorIntentoAsync(int idCompania, int idLiquidacion, short numeroIntento, string error);
     }

--- a/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
+++ b/HG.CFDI.DATA/Repositories/LiquidacionRepository.cs
@@ -71,7 +71,7 @@ namespace HG.CFDI.DATA.Repositories
             return result;
         }
 
-        public async Task RegistrarInicioIntentoAsync(int idCompania, int idLiquidacion, byte estatus, string liquidacionJson)
+        public async Task RegistrarInicioIntentoAsync(int idCompania, int idLiquidacion, byte estatus, string liquidacionJson, string? mensajeCorto = null)
         {
             _logger.LogInformation("Inicio RegistrarInicioIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
             string server = "server2019";
@@ -99,6 +99,8 @@ namespace HG.CFDI.DATA.Repositories
                     entidad.Intentos = nuevoIntento;
                     entidad.UltimoIntento = nuevoIntento;
                     entidad.FechaProximoIntento = null;
+                    if (!string.IsNullOrWhiteSpace(mensajeCorto))
+                        entidad.MensajeCorto = mensajeCorto;
 
                     await context.SaveChangesAsync();
 
@@ -127,7 +129,7 @@ namespace HG.CFDI.DATA.Repositories
             _logger.LogInformation("Fin RegistrarInicioIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
         }
 
-        public async Task ActualizarResultadoIntentoAsync(int idCompania, int idLiquidacion, byte estatus, DateTime? fechaProximoIntento = null)
+        public async Task ActualizarResultadoIntentoAsync(int idCompania, int idLiquidacion, byte estatus, DateTime? fechaProximoIntento = null, string? mensajeCorto = null)
         {
             _logger.LogInformation("Inicio ActualizarResultadoIntentoAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
             string server = "server2019";
@@ -146,6 +148,8 @@ namespace HG.CFDI.DATA.Repositories
 
             entidad.Estatus = estatus;
             entidad.FechaProximoIntento = fechaProximoIntento;
+            if (!string.IsNullOrWhiteSpace(mensajeCorto))
+                entidad.MensajeCorto = mensajeCorto;
             await context.SaveChangesAsync();
 
             var historico = await context.liquidacionOperadorHists


### PR DESCRIPTION
## Summary
- update interface to accept a short message when updating liquidacion status
- set `MensajeCorto` in repository methods
- pass messages from service based on `EstatusLiquidacion`

## Testing
- `dotnet build HG.CFDI.API.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684f849ce1b0832f9133e54c87eb8df2