### PR TITLE
Add liquidacion documents endpoint

### DIFF
--- a/Controllers/CfdiLiquidacionController.cs
+++ b/Controllers/CfdiLiquidacionController.cs
@@ -63,6 +63,26 @@ namespace HG.CFDI.API.Controllers
             }
         }
 
+        [HttpGet("GetDocumentosLiquidacion")]
+        public async Task<IActionResult> GetDocumentosLiquidacion(int idCompania, int idLiquidacion)
+        {
+            try
+            {
+                var response = await _liquidacionService.ObtenerDocumentosTimbradosAsync(idCompania, idLiquidacion);
+                if (!response.IsSuccess)
+                {
+                    return NotFound(response.Mensaje);
+                }
+
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error al obtener documentos de la liquidación");
+                return StatusCode(500, "Internal server error");
+            }
+        }
+
         private static string? ObtenerDatabase(int idCompania)
         {
             return idCompania switch

--- a/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
@@ -8,5 +8,6 @@ namespace HG.CFDI.CORE.Interfaces
     {
         Task<CfdiNomina?> ObtenerLiquidacion(int idCompania, int noLiquidacion);
         Task<UniqueResponse> TimbrarLiquidacionAsync(int idCompania, int noLiquidacion);
+        Task<UniqueResponse> ObtenerDocumentosTimbradosAsync(int idCompania, int idLiquidacion);
     }
 }

--- a/HG.CFDI.SERVICE/Services/LiquidacionService.cs
+++ b/HG.CFDI.SERVICE/Services/LiquidacionService.cs
@@ -170,6 +170,32 @@ namespace HG.CFDI.SERVICE.Services
             return respuesta;
         }
 
+        public async Task<UniqueResponse> ObtenerDocumentosTimbradosAsync(int idCompania, int idLiquidacion)
+        {
+            _logger.LogInformation("Inicio ObtenerDocumentosTimbradosAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
+
+            var registro = await _repository.ObtenerCabeceraAsync(idCompania, idLiquidacion);
+
+            if (registro?.XMLTimbrado != null && registro.PDFTimbrado != null)
+            {
+                _logger.LogInformation("Fin ObtenerDocumentosTimbradosAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
+                return new UniqueResponse
+                {
+                    IsSuccess = true,
+                    Mensaje = "Documentos encontrados",
+                    XmlByteArray = registro.XMLTimbrado,
+                    PdfByteArray = registro.PDFTimbrado
+                };
+            }
+
+            _logger.LogInformation("Fin ObtenerDocumentosTimbradosAsync Compania:{IdCompania} Liquidacion:{IdLiquidacion}", idCompania, idLiquidacion);
+            return new UniqueResponse
+            {
+                IsSuccess = false,
+                Mensaje = "Documentos no encontrados"
+            };
+        }
+
         private async Task RegistrarFalloDeTimbrado(int idCompania, int noLiquidacion, bool transitorio)
         {
             if (transitorio)


### PR DESCRIPTION
## Summary
- support retrieving XML and PDF for a liquidación
- expose new `ObtenerDocumentosTimbradosAsync` service method
- add `GetDocumentosLiquidacion` endpoint

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f95593954832fae23e8c8deb878b4