### PR TITLE
Add liquidaciones listing endpoint

### DIFF
--- a/Controllers/CfdiLiquidacionController.cs
+++ b/Controllers/CfdiLiquidacionController.cs
@@ -1,6 +1,7 @@
 using HG.CFDI.CORE.Interfaces;
 using HG.CFDI.CORE.Models.DtoLiquidacionCfdi;
 using Microsoft.AspNetCore.Mvc;
+using System.Linq;
 
 namespace HG.CFDI.API.Controllers
 {
@@ -38,6 +39,31 @@ namespace HG.CFDI.API.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error al obtener la liquidación");
+                return StatusCode(500, "Internal server error");
+            }
+        }
+
+        [HttpGet("GetLiquidaciones")]
+        public async Task<IActionResult> GetLiquidaciones(string database)
+        {
+            try
+            {
+                int? idCompania = ObtenerIdCompania(database);
+                if (idCompania is null)
+                {
+                    return BadRequest("Base de datos no válida");
+                }
+
+                var liquidaciones = await _liquidacionService.ObtenerLiquidacionesAsync(idCompania.Value);
+                if (liquidaciones == null || !liquidaciones.Any())
+                {
+                    return NotFound();
+                }
+                return Ok(liquidaciones);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error al obtener las liquidaciones");
                 return StatusCode(500, "Internal server error");
             }
         }

--- a/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionRepository.cs
@@ -6,6 +6,7 @@ namespace HG.CFDI.CORE.Interfaces
     public interface ILiquidacionRepository
     {
         Task<string?> ObtenerDatosNominaJson(string database, int idLiquidacion);
+        Task<string?> ObtenerLiquidacionesJson(string database);
 
         Task InsertarDocTimbradoLiqAsync(int idCompania, int idLiquidacion, byte[]? xmlTimbrado, byte[]? pdfTimbrado, string? uuid);
 

--- a/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
+++ b/HG.CFDI.CORE/Interfaces/ILiquidacionService.cs
@@ -7,6 +7,7 @@ namespace HG.CFDI.CORE.Interfaces
     public interface ILiquidacionService
     {
         Task<CfdiNomina?> ObtenerLiquidacion(int idCompania, int noLiquidacion);
+        Task<List<LiquidacionDto>> ObtenerLiquidacionesAsync(int idCompania);
         Task<UniqueResponse> TimbrarLiquidacionAsync(int idCompania, int noLiquidacion);
         Task<UniqueResponse> ObtenerDocumentosTimbradosAsync(int idCompania, int idLiquidacion);
     }

--- a/HG.CFDI.CORE/Models/DTO/LiquidacionDto.cs
+++ b/HG.CFDI.CORE/Models/DTO/LiquidacionDto.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace HG.CFDI.CORE.Models.DtoLiquidacionCfdi
+{
+    public class LiquidacionDto
+    {
+        public int IdLiquidacion { get; set; }
+        public string Nombre { get; set; }
+        public string Rfc { get; set; }
+        public DateTime Fecha { get; set; }
+        public short Intentos { get; set; }
+        public DateTime? ProximoIntento { get; set; }
+        public string? Xml { get; set; }
+        public string? Pdf { get; set; }
+        public string? Uuid { get; set; }
+    }
+}

--- a/HG.CFDI.SERVICE/Services/LiquidacionService.cs
+++ b/HG.CFDI.SERVICE/Services/LiquidacionService.cs
@@ -57,6 +57,36 @@ namespace HG.CFDI.SERVICE.Services
                 return null;
             }
         }
+
+        public async Task<List<LiquidacionDto>> ObtenerLiquidacionesAsync(int idCompania)
+        {
+            _logger.LogInformation("Inicio ObtenerLiquidaciones Compania:{IdCompania}", idCompania);
+            string? database = ObtenerDatabase(idCompania);
+            if (string.IsNullOrEmpty(database))
+            {
+                _logger.LogInformation("Fin ObtenerLiquidaciones Compania:{IdCompania}", idCompania);
+                return new List<LiquidacionDto>();
+            }
+
+            var json = await _repository.ObtenerLiquidacionesJson(database);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                _logger.LogInformation("Fin ObtenerLiquidaciones Compania:{IdCompania}", idCompania);
+                return new List<LiquidacionDto>();
+            }
+
+            try
+            {
+                var result = JsonSerializer.Deserialize<List<LiquidacionDto>>(json);
+                _logger.LogInformation("Fin ObtenerLiquidaciones Compania:{IdCompania}", idCompania);
+                return result ?? new List<LiquidacionDto>();
+            }
+            catch
+            {
+                _logger.LogInformation("Fin ObtenerLiquidaciones Compania:{IdCompania}", idCompania);
+                return new List<LiquidacionDto>();
+            }
+        }
      
         public async Task<UniqueResponse> TimbrarLiquidacionAsync(int idCompania, int noLiquidacion)
         {


### PR DESCRIPTION
## Summary
- add LiquidacionDto model
- extend repository and service to fetch liquidaciones JSON from stored procedure
- expose `GetLiquidaciones` endpoint in `CfdiLiquidacionController`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d384e908832f98e9aab5926b31f0