### PR TITLE
Handle errors from BuzonE liquidacion response

### DIFF
--- a/HG.CFDI.SERVICE/Services/LiquidacionService.cs
+++ b/HG.CFDI.SERVICE/Services/LiquidacionService.cs
@@ -161,12 +161,23 @@ namespace HG.CFDI.SERVICE.Services
                     respuesta.IsSuccess = false;
                     respuesta.Mensaje = responseServicio?.mensaje ?? "Error en timbrado";
 
-                    //FALTA TOMAR EN CUENTA ErrorList
                     string mensajeError = responseServicio?.mensajeErrorTimbrado ?? respuesta.Mensaje;
                     if (!string.IsNullOrWhiteSpace(responseServicio?.mensajeErrorTimbrado))
                         respuesta.Errores.Add(responseServicio.mensajeErrorTimbrado);
 
                     var cabeceraActual = await _repository.ObtenerCabeceraAsync(idCompania, noLiquidacion);
+                    if (responseServicio?.errorList != null)
+                    {
+                        foreach (var error in responseServicio.errorList)
+                        {
+                            string err = $"{error.message}{error.detail}";
+                            respuesta.Errores.Add(err);
+                            mensajeError += $" | {err}";
+                            if (cabeceraActual != null)
+                                await _repository.RegistrarErrorIntentoAsync(idCompania, noLiquidacion, cabeceraActual.UltimoIntento, err);
+                        }
+                    }
+
                     if (cabeceraActual != null)
                         await _repository.RegistrarErrorIntentoAsync(idCompania, noLiquidacion, cabeceraActual.UltimoIntento, mensajeError);
                 }


### PR DESCRIPTION
## Summary
- save details from `responseServicio.errorList` when timbrado fails
- store each error in the response and database

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e5b27b58832f8f99fb8be3128515